### PR TITLE
Manually Count CC - `get_canonical_form_slice`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # Code-Coverage
+
+## Cyclomatic Complexity
+- subtensor.py - `get_canonical_form_slice`: 23 edges, 10 nodes, 1 connected components =  15 CC


### PR DESCRIPTION
Fix #41 


The commented Code:

```
def get_canonical_form_slice(
    theslice: Union[slice, Variable], length: Variable
) -> tuple[Variable, int]:
    """Convert slices to canonical form.

    Given a slice [start:stop:step] transform it into a canonical form
    that respects the conventions imposed by python and numpy.

    In a canonical form a slice is represented by a canonical form slice,
    in which 0 <= start <= stop <= length and step > 0, and a flag which says
    if the resulting set of numbers needs to be reversed or not.

    """
    from pytensor.tensor import ge, lt, sign, switch

    if not isinstance(theslice, slice):     # Edge 1
        try:        # Edge 2
            value = as_index_literal(theslice)
        except NotScalarConstantError:
            value = theslice

        value = switch(lt(value, 0), (value + length), value)

        return value, 1     # Node 1

    def analyze(x):
        try:
            x_constant = as_index_literal(x)
            is_constant = True
        except NotScalarConstantError:
            x_constant = x
            is_constant = False
        return x_constant, is_constant

    start, is_start_constant = analyze(theslice.start)
    stop, is_stop_constant = analyze(theslice.stop)
    step, is_step_constant = analyze(theslice.step)
    length, is_length_constant = analyze(length)

    if (
        is_start_constant
        and is_stop_constant
        and is_step_constant
        and is_length_constant
    ):      # Edge 3
        _start, _stop, _step = slice(start, stop, step).indices(length)
        if _start <= _stop and _step >= 1:      # Edge 4
            return slice(_start, _stop, _step), 1       # Node 2

    if step is None:        # Edge 5
        step = 1
        is_step_constant = True

    # First handle the easier and common case where `step` is 1 and
    # either `start` or `stop` is a range boundary. More specializations
    # could be added later. This makes the resulting graph smaller than
    # in the generic case below.
    if step == 1:       # Edge 6
        is_start_0 = (
            start is None
            or start == 0
            or (
                is_start_constant
                and is_length_constant
                and start < 0
                and start + length <= 0
            )
        )       # Edge 7
        is_stop_length = (
            stop is None
            or stop in [length, sys.maxsize]
            or (is_stop_constant and is_length_constant and stop >= length)
        )       # Edge 8
        if is_start_0:      # Edge 9
            # 0:stop:1
            if is_stop_length:      # Edge 10
                # Full slice.
                return slice(0, length, 1), 1       # Node 3
            if is_stop_constant and stop >= 0:      # Edge 11
                return (slice(0, switch(lt(stop, length), stop, length), 1), 1)     # Node 4
            stop_plus_len = stop + length
            stop = switch(
                lt(stop, 0),
                # stop < 0
                switch(
                    lt(stop_plus_len, 0),
                    # stop + len < 0
                    0,
                    # stop + len >= 0
                    stop_plus_len,
                ),
                # stop >= 0: use min(stop, length)
                switch(lt(stop, length), stop, length),
            )
            return slice(0, stop, 1), 1     # Node 5
        elif is_stop_length:        # Edge 12
            # start:length:1
            if is_start_constant and start >= 0:        # Edge 13
                return slice(switch(lt(start, length), start, length), length, 1), 1        # Node 6
            start_plus_len = start + length
            start = switch(
                lt(start, 0),
                # start < 0
                switch(
                    lt(start_plus_len, 0),
                    # start + len < 0
                    0,
                    # start + len >= 0
                    start_plus_len,
                ),
                # start >= 0: use min(start, length)
                switch(lt(start, length), start, length),
            )
            return slice(start, length, 1), 1       # Node 7

    # This is the generic case.

    if is_step_constant:        # Edge 14
        # When we know the sign of `step`, the graph can be made simpler.
        assert step != 0    # Node 8
        if step > 0:        # Edge 15

            def switch_neg_step(a, b):
                return b

            abs_step = step
            sgn_step = 1
        else:       # Edge 16

            def switch_neg_step(a, b):
                return a

            abs_step = -step
            sgn_step = -1
    else:       # Edge 17
        is_step_neg = lt(step, 0)

        def switch_neg_step(a, b):
            return switch(is_step_neg, a, b)

        abs_step = abs(step)
        sgn_step = sign(step)

    defstart = switch_neg_step(length - 1, 0)
    defstop = switch_neg_step(-1, length)
    if start is None:       # Edge 18
        start = defstart
    else:       # Edge 19
        start = switch(lt(start, 0), start + length, start)
        start = switch(lt(start, 0), switch_neg_step(-1, 0), start)
        start = switch(ge(start, length), switch_neg_step(length - 1, length), start)
    if stop is None or stop == sys.maxsize:     # Edge 20
        # The special "maxsize" case is probably not needed here,
        # as slices containing maxsize are not generated by
        # __getslice__ anymore.
        stop = defstop
    else:       # Edge 21
        stop = switch(lt(stop, 0), stop + length, stop)
        stop = switch(lt(stop, 0), -1, stop)
        stop = switch(ge(stop, length), length, stop)

    nw_stop = switch_neg_step(start + 1, stop)
    slice_len = (start - stop - 1) // abs_step + 1
    slice_len = switch(lt(slice_len, 0), 0, slice_len)
    neg_start = nw_stop - (slice_len - 1) * abs_step - 1
    neg_start = switch(lt(neg_start, 0), (nw_stop - 1), neg_start)
    nw_start = switch_neg_step(neg_start, start)
    nw_start = switch(lt(nw_start, 0), 0, nw_start)
    nw_stop = switch(lt(nw_stop, 0), 0, nw_stop)
    # Ensure start <= stop.
    nw_start = switch(lt(nw_start, nw_stop), nw_start, nw_stop)

    nw_step = abs_step
    if step != 1:       # Edge 22
        reverse = sgn_step
        return slice(nw_start, nw_stop, nw_step), reverse       # Node 9
    else:       # Edge 23
        return slice(nw_start, nw_stop, nw_step), 1     # Node 10
 def get_canonical_form_slice(
    theslice: Union[slice, Variable], length: Variable
) -> tuple[Variable, int]:
    """Convert slices to canonical form.

    Given a slice [start:stop:step] transform it into a canonical form
    that respects the conventions imposed by python and numpy.

    In a canonical form a slice is represented by a canonical form slice,
    in which 0 <= start <= stop <= length and step > 0, and a flag which says
    if the resulting set of numbers needs to be reversed or not.

    """
    from pytensor.tensor import ge, lt, sign, switch

    if not isinstance(theslice, slice):     # Edge 1
        try:        # Edge 2
            value = as_index_literal(theslice)
        except NotScalarConstantError:
            value = theslice

        value = switch(lt(value, 0), (value + length), value)

        return value, 1     # Node 1

    def analyze(x):
        try:
            x_constant = as_index_literal(x)
            is_constant = True
        except NotScalarConstantError:
            x_constant = x
            is_constant = False
        return x_constant, is_constant

    start, is_start_constant = analyze(theslice.start)
    stop, is_stop_constant = analyze(theslice.stop)
    step, is_step_constant = analyze(theslice.step)
    length, is_length_constant = analyze(length)

    if (
        is_start_constant
        and is_stop_constant
        and is_step_constant
        and is_length_constant
    ):      # Edge 3
        _start, _stop, _step = slice(start, stop, step).indices(length)
        if _start <= _stop and _step >= 1:      # Edge 4
            return slice(_start, _stop, _step), 1       # Node 2

    if step is None:        # Edge 5
        step = 1
        is_step_constant = True

    # First handle the easier and common case where `step` is 1 and
    # either `start` or `stop` is a range boundary. More specializations
    # could be added later. This makes the resulting graph smaller than
    # in the generic case below.
    if step == 1:       # Edge 6
        is_start_0 = (
            start is None
            or start == 0
            or (
                is_start_constant
                and is_length_constant
                and start < 0
                and start + length <= 0
            )
        )       # Edge 7
        is_stop_length = (
            stop is None
            or stop in [length, sys.maxsize]
            or (is_stop_constant and is_length_constant and stop >= length)
        )       # Edge 8
        if is_start_0:      # Edge 9
            # 0:stop:1
            if is_stop_length:      # Edge 10
                # Full slice.
                return slice(0, length, 1), 1       # Node 3
            if is_stop_constant and stop >= 0:      # Edge 11
                return (slice(0, switch(lt(stop, length), stop, length), 1), 1)     # Node 4
            stop_plus_len = stop + length
            stop = switch(
                lt(stop, 0),
                # stop < 0
                switch(
                    lt(stop_plus_len, 0),
                    # stop + len < 0
                    0,
                    # stop + len >= 0
                    stop_plus_len,
                ),
                # stop >= 0: use min(stop, length)
                switch(lt(stop, length), stop, length),
            )
            return slice(0, stop, 1), 1     # Node 5
        elif is_stop_length:        # Edge 12
            # start:length:1
            if is_start_constant and start >= 0:        # Edge 13
                return slice(switch(lt(start, length), start, length), length, 1), 1        # Node 6
            start_plus_len = start + length
            start = switch(
                lt(start, 0),
                # start < 0
                switch(
                    lt(start_plus_len, 0),
                    # start + len < 0
                    0,
                    # start + len >= 0
                    start_plus_len,
                ),
                # start >= 0: use min(start, length)
                switch(lt(start, length), start, length),
            )
            return slice(start, length, 1), 1       # Node 7

    # This is the generic case.

    if is_step_constant:        # Edge 14
        # When we know the sign of `step`, the graph can be made simpler.
        assert step != 0    # Node 8
        if step > 0:        # Edge 15

            def switch_neg_step(a, b):
                return b

            abs_step = step
            sgn_step = 1
        else:       # Edge 16

            def switch_neg_step(a, b):
                return a

            abs_step = -step
            sgn_step = -1
    else:       # Edge 17
        is_step_neg = lt(step, 0)

        def switch_neg_step(a, b):
            return switch(is_step_neg, a, b)

        abs_step = abs(step)
        sgn_step = sign(step)

    defstart = switch_neg_step(length - 1, 0)
    defstop = switch_neg_step(-1, length)
    if start is None:       # Edge 18
        start = defstart
    else:       # Edge 19
        start = switch(lt(start, 0), start + length, start)
        start = switch(lt(start, 0), switch_neg_step(-1, 0), start)
        start = switch(ge(start, length), switch_neg_step(length - 1, length), start)
    if stop is None or stop == sys.maxsize:     # Edge 20
        # The special "maxsize" case is probably not needed here,
        # as slices containing maxsize are not generated by
        # __getslice__ anymore.
        stop = defstop
    else:       # Edge 21
        stop = switch(lt(stop, 0), stop + length, stop)
        stop = switch(lt(stop, 0), -1, stop)
        stop = switch(ge(stop, length), length, stop)

    nw_stop = switch_neg_step(start + 1, stop)
    slice_len = (start - stop - 1) // abs_step + 1
    slice_len = switch(lt(slice_len, 0), 0, slice_len)
    neg_start = nw_stop - (slice_len - 1) * abs_step - 1
    neg_start = switch(lt(neg_start, 0), (nw_stop - 1), neg_start)
    nw_start = switch_neg_step(neg_start, start)
    nw_start = switch(lt(nw_start, 0), 0, nw_start)
    nw_stop = switch(lt(nw_stop, 0), 0, nw_stop)
    # Ensure start <= stop.
    nw_start = switch(lt(nw_start, nw_stop), nw_start, nw_stop)

    nw_step = abs_step
    if step != 1:       # Edge 22
        reverse = sgn_step
        return slice(nw_start, nw_stop, nw_step), reverse       # Node 9
    else:       # Edge 23
        return slice(nw_start, nw_stop, nw_step), 1     # Node 10
```